### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const fetchPlanets = () => {
 ```ts
 import { defineStore } from 'pinia';
 import { gql } from 'nuxt-graphql-request/utils';
-import { useNuxtApp } from 'nuxt/app';
+import { useNuxtApp } from '#imports';
 
 type Planet = { id: number; name: string };
 

--- a/docs/content/en/usage/store.md
+++ b/docs/content/en/usage/store.md
@@ -10,7 +10,7 @@ category: 'Usage'
 ```ts
 import { defineStore } from 'pinia';
 import { gql } from 'nuxt-graphql-request/utils';
-import { useNuxtApp } from 'nuxt/app';
+import { useNuxtApp } from '#imports';
 
 type Planet = { id: number; name: string };
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -34,7 +34,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { useAsyncData, useNuxtApp } from 'nuxt/app';
+import { useAsyncData, useNuxtApp } from '#imports';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { parse } from 'graphql';
 import { gql } from 'graphql-request';

--- a/playground/plugins/pinia.ts
+++ b/playground/plugins/pinia.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from 'nuxt/app';
+import { defineNuxtPlugin } from '#imports';
 import type { Pinia } from 'pinia';
 import { useMainStore } from '~/store';
 

--- a/playground/store/index.ts
+++ b/playground/store/index.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 import { gql } from 'graphql-request';
-import { useNuxtApp } from 'nuxt/app';
+import { useNuxtApp } from '#imports';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { parse } from 'graphql';
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from 'nuxt/app';
+import { defineNuxtPlugin } from '#imports';
 import { GraphQLClient } from 'graphql-request';
 import { mergeAll } from 'ramda';
 import type { ModuleOptions } from '../module';

--- a/test/fixture/pages/batch.vue
+++ b/test/fixture/pages/batch.vue
@@ -28,7 +28,7 @@ export default {
 </script>
 
 <script setup>
-import { useAsyncData, useNuxtApp } from 'nuxt/app';
+import { useAsyncData, useNuxtApp } from '#imports';
 import { gql } from '../../../src/utils';
 
 const { $graphql } = useNuxtApp();

--- a/test/fixture/pages/import.vue
+++ b/test/fixture/pages/import.vue
@@ -28,7 +28,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { useAsyncData, useNuxtApp } from 'nuxt/app';
+import { useAsyncData, useNuxtApp } from '#imports';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 import countriesQuery from '../graphql/query/countries.gql';

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -28,7 +28,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { useAsyncData, useNuxtApp } from 'nuxt/app';
+import { useAsyncData, useNuxtApp } from '#imports';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { parse } from 'graphql';
 import { gql } from '../../../src/utils';

--- a/test/fixture/pages/runtime.vue
+++ b/test/fixture/pages/runtime.vue
@@ -28,7 +28,7 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { useAsyncData, useNuxtApp } from 'nuxt/app';
+import { useAsyncData, useNuxtApp } from '#imports';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { parse } from 'graphql';
 import { gql } from '../../../src/utils';

--- a/test/fixture/pages/with-ast.vue
+++ b/test/fixture/pages/with-ast.vue
@@ -28,7 +28,7 @@ export default {
 </script>
 
 <script setup>
-import { useAsyncData, useNuxtApp } from 'nuxt/app';
+import { useAsyncData, useNuxtApp } from '#imports';
 import { gql } from '../../../src/utils';
 
 const { $graphql } = useNuxtApp();


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.