### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,6 @@
 
 ## Setup
 
-Install with yarn:
-
-```bash
-npx nuxi@latest module add graphql-request
-```
-
-Install with npm:
-
 ```bash
 npx nuxi@latest module add graphql-request
 ```
@@ -40,7 +32,7 @@ For Nuxt2, use nuxt-graphql-request v6:
 
 ```bash
 
-npx nuxi@latest module add graphql-request
+yarn add nuxt-graphql-request@v6 graphql --dev
 ```
 
 **nuxt.config.js**

--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@
 Install with yarn:
 
 ```bash
-yarn add nuxt-graphql-request graphql --dev
+npx nuxi@latest module add graphql-request
 ```
 
 Install with npm:
 
 ```bash
-npm install nuxt-graphql-request graphql --save-dev
+npx nuxi@latest module add graphql-request
 ```
 
 For Nuxt2, use nuxt-graphql-request v6:
 
 ```bash
 
-yarn add nuxt-graphql-request@v6 graphql --dev
+npx nuxi@latest module add graphql-request
 ```
 
 **nuxt.config.js**

--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -11,7 +11,7 @@ category: 'Guide'
   <code-block label="yarn" active>
 
 ```bash
-yarn add nuxt-graphql-request graphql --dev
+npx nuxi@latest module add graphql-request
 ```
 
   </code-block>
@@ -19,7 +19,7 @@ yarn add nuxt-graphql-request graphql --dev
   <code-block label="npm">
 
 ```bash
-npm install nuxt-graphql-request graphql --save-dev
+npx nuxi@latest module add graphql-request
 ```
 
   </code-block>
@@ -27,7 +27,7 @@ npm install nuxt-graphql-request graphql --save-dev
   <code-block label="pnpm">
 
 ```bash
-pnpm add nuxt-graphql-request graphql -D
+npx nuxi@latest module add graphql-request
 ```
 
   </code-block>
@@ -37,7 +37,7 @@ pnpm add nuxt-graphql-request graphql -D
 For Nuxt2, use nuxt-graphql-request v6:
 
 ```bash
-yarn add nuxt-graphql-request@v6 graphql --dev
+npx nuxi@latest module add graphql-request
 ```
 
 ## **nuxt.config.ts**

--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -16,28 +16,13 @@ npx nuxi@latest module add graphql-request
 
   </code-block>
 
-  <code-block label="npm">
-
-```bash
-npx nuxi@latest module add graphql-request
-```
-
-  </code-block>
-
-  <code-block label="pnpm">
-
-```bash
-npx nuxi@latest module add graphql-request
-```
-
-  </code-block>
 
 </code-group>
 
 For Nuxt2, use nuxt-graphql-request v6:
 
 ```bash
-npx nuxi@latest module add graphql-request
+yarn add nuxt-graphql-request@v6 graphql --dev
 ```
 
 ## **nuxt.config.ts**

--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -8,7 +8,7 @@ category: 'Guide'
 ## Install
 
 <code-group>
-  <code-block label="yarn" active>
+  <code-block label="nuxi" active>
 
 ```bash
 npx nuxi@latest module add graphql-request


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
